### PR TITLE
Merge florentvaldelievre/virtualartifacts-webintent#4

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,6 +16,7 @@
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="WebIntent" >
                 <param name="android-package" value="com.borismus.webintent.WebIntent"/>
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 


### PR DESCRIPTION
This PR merges florentvaldelievre/virtualartifacts-webintent#4, which forces the plugin to load on startup to address various issues that the original PR intended to solve. It is being raised as part of a routine cleanup of the organization that the head repo is part of.